### PR TITLE
Link to Lilypond home page at first mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # lyp - The Lilypond Swiss Army Knife
 
-Use lyp to install and manage packages for Lilypond, install and manage multiple versions of Lilypond on your machine, and improve your Lilypond workflow.
+Use lyp to install and manage packages for [Lilypond](http://lilypond.org/), install and manage multiple versions of Lilypond on your machine, and improve your Lilypond workflow.
 
 __Code reuse__: lyp lets you install packages that act as Lilypond code libraries and can be used to enhance your Lilypond files with additional functionality. Packages can depend on other packages. Lyp resolves both direct and transitive package dependencies, and automatically selects the correct version to use for each package.
 


### PR DESCRIPTION
Don't assume the reader knows what Lilypond is.  Instead, link to its
home page at first mention, for the convenience of curious newcomers.